### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,7 +1,7 @@
-Mux			KEYWORD1
-open		KEYWORD2
-demuxMe		KEYWORD2
+Mux	KEYWORD1
+open	KEYWORD2
+demuxMe	KEYWORD2
 goDigital	KEYWORD2
-assign		KEYWORD2
-write		KEYWORD2
-read		KEYWORD2
+assign	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords